### PR TITLE
Change use of comports() list for POSIX platforms

### DIFF
--- a/Nexus.py
+++ b/Nexus.py
@@ -31,7 +31,7 @@ class Nexus:
         self.mcuCode      = -1
         self.serialNum    = ""
         self.flashSizeStr = ""
-        self.ports        = [p.name for p in availablePorts()]
+        self.ports        = [p.device for p in availablePorts()]
         if port:
             if port not in self.ports:
                 raise Exception("Specified port not available ({} not in {})".format(port, self.ports))
@@ -236,7 +236,7 @@ if __name__ == "__main__":
                              "connection has been established will be used for the upload, too (can be slow!).")
 
     args = parser.parse_args()
-    ports = [p.name for p in availablePorts()]
+    ports = [p.device for p in availablePorts()]
     portsStr = ", ".join(ports)
     if args.list:
         print("List of available serial ports:")


### PR DESCRIPTION
When run on Linux, this script would barf endlessly because the "name" of a comport is not the same as the "device" of the comport list object. When you go to try and open a device that isn't listed as "/dev/ttyUSB0", it would crash out rather vaguely with "Cannot connect to device".